### PR TITLE
Adding adjoint and 2-adjoint equivalences

### DIFF
--- a/src/hott/types/2adj.lean
+++ b/src/hott/types/2adj.lean
@@ -1,0 +1,112 @@
+/-
+Authors: Daniel Carranza, Jonathan Chang, Ryan Sandford
+Under the supervision of Chris Kapulkin
+-/
+
+import hott.init hott.types.sigma hott.types.prod hott.types.pi hott.types.fiber hott.types.equiv .adj
+
+open hott hott.eq
+
+hott_theory
+universes u v
+
+section
+
+    variable {A: Type u}
+    variable {B: Type v}
+    
+    @[hott] def nat_homotopy {A : Type u} {B : Type _} (g : B → A) (f : A → B) (H : g ∘ f ~ id) (x : A) 
+      : H (g (f x)) = ap g (ap f (H x)) :=
+    cancel_right (H x) (ap_con_eq_con H (H x))⁻¹ ⬝ ap_compose g f _
+
+    @[hott] def r2coh (f: A → B) (h: fae f) (x: A)
+            : Type _ :=
+        (nat_homotopy h.1.1 f h.1.2.1 x)⁻¹ ⬝ h.2.2 (f x) = ap02 h.1.1 (h.2.1 x)
+    
+    @[hott] def l2coh (f: A → B) (h: fae f) (y: B)
+            : Type _ :=
+        h.2.1 (h.1.1 y) ⬝ nat_homotopy f h.1.1 h.1.2.2 y = ap02 f (h.2.2 y)
+
+    @[hott] def is_2hae (f: A → B) : Type _ :=
+        Σ(h: fae f), Π(x: A), r2coh f h x 
+    
+    @[hott] def is_2hae_l (f: A → B) : Type _ :=
+        Σ(h: fae f), Π(y: B), l2coh f h y
+
+    @[hott] def two_fae (f: A → B) : Type _ :=
+        Σ(h: fae f), (Π(x: A), r2coh f h x) × (Π(y: B), l2coh f h y)
+
+    @[hott] def is_contr_r2coh (f: A → B) (h: is_hae_l f)
+            : is_contr Σ(r: Π(x: A), rcoh f h.1 x), Π(x: A), r2coh f ⟨h.1, (r, h.2)⟩ x :=
+        begin
+            fapply is_trunc.is_trunc_equiv_closed -2,
+                exact (sigma.sigma_pi_equiv_pi_sigma 
+                    (λ (x: A) (r: rcoh f h.1 x), 
+                        (nat_homotopy h.1.1 f h.1.2.1 x)⁻¹ ⬝ h.2 (f x) = ap02 h.1.1 r
+                    ))⁻¹ᵉ,
+            apply pi.is_trunc_pi _ -2,
+                intro x,
+                fapply is_trunc.is_trunc_equiv_closed -2,
+                exact fiber.fiber_eq_equiv 
+                    (fiber.mk (ap f (h.1.2.1 x)) ((nat_homotopy h.1.1 f h.1.2.1 x)⁻¹ ⬝ h.2 (f x)))
+                    (fiber.mk (h.1.2.2 (f x)) rfl),
+                apply is_trunc.is_contr_eq _ _,
+                exact @is_equiv.is_contr_fiber_of_is_equiv _ _ (ap h.1.1) (ap_g_is_equiv h.1 _ _) _
+        end
+    
+    @[hott] def is_2hae_equiv_sigma_char (f: A → B)
+            : is_2hae f ≃ Σ(u: is_hae_l f), Σ(r: Π(x: A), rcoh f u.1 x), Π(x: A), r2coh f ⟨u.1, (r, u.2)⟩ x :=
+        begin
+            apply hott.equiv.trans,
+            exact (sigma.sigma_assoc_equiv (λ e: fae f, Π(x: A), r2coh f e x))⁻¹ᵉ,
+            apply hott.equiv.trans,
+            apply sigma.sigma_equiv_sigma_right,
+            intro q,
+            apply (
+                sigma.sigma_equiv_sigma_left 
+                    (λ p: (Π(x: A), rcoh f q x) × (Π(y: B), lcoh f q y), 
+                        Π(x: A), r2coh f ⟨q, p⟩ x) 
+                    (prod.prod_comm_equiv _ _)
+            ),
+            apply hott.equiv.trans,
+            dsimp,
+            apply sigma.sigma_equiv_sigma_right,
+            intro q,
+            apply (
+                sigma.sigma_equiv_sigma_left
+                    (λ p: (Π(y: B), lcoh f q y) × (Π(x: A), rcoh f q x),
+                        Π(x: A), r2coh f ⟨q, (prod.prod_comm_equiv _ _).to_inv p⟩ x)
+                    (sigma.equiv_prod _ _)⁻¹ᵉ
+            ),
+            apply hott.equiv.trans,
+            apply sigma.sigma_equiv_sigma_right,
+            intro q,
+            dsimp,
+            exact (sigma.sigma_assoc_equiv 
+                (λ u: Σ(l: Π(y: B), lcoh f q y), 
+                        Π(x: A), rcoh f q x, Π(x: A), 
+                r2coh f ⟨q,
+            ((prod.prod_comm_equiv (Π (x : A), rcoh f q x) (Π (y : B), lcoh f q y)).to_fun)⁻¹ᶠ
+              ((sigma.equiv_prod (Π (y : B), lcoh f q y) (Π (x : A), rcoh f q x)).to_fun u)⟩ x))⁻¹ᵉ,
+            exact (sigma.sigma_assoc_equiv (λ e: is_hae_l f, Σ(r: Π(x: A), rcoh f e.1 x), Π(x: A), r2coh f ⟨e.1, (r, e.2)⟩ x)),
+        end
+    
+    @[hott] def is_2hae_is_contr (f: A → B) (h: is_2hae f) 
+            : is_contr (is_2hae f) :=  
+        begin
+            apply is_trunc.is_trunc_equiv_closed -2 (is_2hae_equiv_sigma_char f)⁻¹ᵉ,
+            refine @sigma.is_trunc_sigma _ (λ e: Σ(q: qinv f), Π(y: B), lcoh f q y, Σ(r: Π(x: A), rcoh f e.1 x), Π(x: A), r2coh f ⟨e.1, (r, e.2)⟩ x) -2 (_: _) (_: _),
+            exact is_hae_l_is_contr f ⟨h.1.1, h.1.2.2⟩,
+            exact is_contr_r2coh f
+        end
+
+    @[hott] def fae_to_2hae (f: A → B) : fae f → is_2hae f :=
+        λ e, begin
+            have u : Π(h: is_hae_l f), 
+                    Σ(r: Π(x: A), rcoh f h.1 x), 
+                        Π(x: A), r2coh f ⟨h.1, (r, h.2)⟩ x
+                := λ h, @is_trunc.center _ (is_contr_r2coh f h),
+            exact ⟨⟨e.1, ((u ⟨e.1, e.2.2⟩).1, e.2.2)⟩, (u ⟨e.1, e.2.2⟩).2⟩ 
+        end
+
+end 

--- a/src/hott/types/adj.lean
+++ b/src/hott/types/adj.lean
@@ -1,0 +1,146 @@
+/-
+Authors: Daniel Carranza, Jonathan Chang, Ryan Sandford
+Under the supervision of Chris Kapulkin
+-/
+
+import hott.init hott.types.sigma hott.types.prod hott.types.pi hott.types.fiber hott.types.equiv
+
+open hott hott.eq
+
+hott_theory
+universes u v
+
+section
+
+    variable {A: Type u}
+    variable {B: Type v}
+
+    @[hott] def linv (g: B → A) (f: A → B) : Type _ := g ∘ f ~ id
+
+    @[hott] def rinv (g: B → A) (f: A → B) : Type _ := f ∘ g ~ id
+
+    @[hott] def has_linv (f: A → B) : Type _ := Σ(g: B → A), linv g f
+
+    @[hott] def has_rinv (f: A → B) : Type _ := Σ(g: B → A), rinv g f
+
+    @[hott] def qinv (f: A → B) : Type _ := Σ(g: B → A), linv g f × rinv g f
+
+    @[hott] def qinv_to_is_equiv {f: A → B} 
+            : qinv f → is_equiv f :=
+        λ e, is_equiv.adjointify f e.1 e.2.2 e.2.1
+
+    @[hott] def is_contr_has_linv (f: A → B) (e: qinv f) 
+            : is_contr (has_linv f) :=
+        begin 
+            apply is_trunc.is_trunc_equiv_closed -2,
+            exact sigma.sigma_equiv_sigma_right 
+                (λ g: B → A, (eq_equiv_homotopy (g ∘ f) id)),
+            apply is_trunc.is_trunc_equiv_closed -2,
+            exact fiber.sigma_char 
+                (pi.arrow_equiv_arrow_left A (equiv.mk f (qinv_to_is_equiv e))⁻¹ᵉ).to_fun
+                id,
+            exact @is_equiv.is_contr_fiber_of_is_equiv _ _
+                (pi.arrow_equiv_arrow_left A (equiv.mk f (qinv_to_is_equiv e))⁻¹ᵉ).to_fun
+                (pi.arrow_equiv_arrow_left A (equiv.mk f (qinv_to_is_equiv e))⁻¹ᵉ).to_is_equiv
+                id
+        end
+
+    @[hott] def is_contr_has_rinv (f: A → B) (e: qinv f)
+            : is_contr (has_rinv f) :=
+        begin
+            apply is_trunc.is_trunc_equiv_closed -2,
+            exact sigma.sigma_equiv_sigma_right 
+                (λ g: B → A, (eq_equiv_homotopy (f ∘ g) id)),
+            apply is_trunc.is_trunc_equiv_closed -2,
+            exact fiber.sigma_char 
+                (pi.arrow_equiv_arrow_right B (equiv.mk f (qinv_to_is_equiv e))).to_fun
+                id,
+            exact @is_equiv.is_contr_fiber_of_is_equiv _ _
+                (pi.arrow_equiv_arrow_right B (equiv.mk f (qinv_to_is_equiv e))).to_fun
+                (pi.arrow_equiv_arrow_right B (equiv.mk f (qinv_to_is_equiv e))).to_is_equiv
+                id
+        end
+
+    @[hott] def rcoh (f: A → B) (h: qinv f) (x: A)
+            : Type _ :=
+        ap f (h.2.1 x) = h.2.2 (f x)
+
+    @[hott] def lcoh (f: A → B) (h: qinv f) (y: B)
+            : Type _ :=
+        h.2.1 (h.1 y) = ap h.1 (h.2.2 y)
+
+    @[hott] def is_hae (f: A → B) : Type _ :=
+        Σ(h: qinv f), Π(x: A), rcoh f h x
+    
+    @[hott] def is_hae_to_is_equiv {f: A → B}
+            : is_hae f → is_equiv f :=
+        λ e: is_hae f, is_equiv.mk' e.1.1 e.1.2.2 e.1.2.1 (λ x: A, (e.2 x)⁻¹)
+
+    @[hott] def ap_g_is_equiv {f: A → B} (e: qinv f) (b b': B)
+            : is_equiv (@ap B A e.1 b b') :=
+        @is_equiv.is_equiv_ap _ _ e.1 (@is_equiv.is_equiv_inv _ _ f (qinv_to_is_equiv e)) _ _
+
+    @[hott] def is_hae_l (f: A → B) : Type _ :=
+        Σ(h: qinv f), Π(y: B), lcoh f h y
+
+    @[hott] def is_contr_lcoh (f: A → B) (h: qinv f)
+            : is_contr Σ(r: rinv h.1 f), Π(y: B), lcoh f ⟨h.1, (h.2.1, r)⟩ y :=
+        begin
+            apply is_trunc.is_trunc_equiv_closed -2,
+            exact (sigma.sigma_pi_equiv_pi_sigma
+                (λ (y: B) (r: f (h.1 y) = y), h.2.1 (h.1 y) = ap h.1 r))⁻¹ᵉ,
+            apply pi.is_trunc_pi _ -2,
+            intro y,
+            apply is_trunc.is_trunc_equiv_closed -2,
+            exact fiber.fiber_eq_equiv
+                (fiber.mk (f (h.1 y)) (h.2.1 (h.1 y)))
+                (fiber.mk y rfl),
+            apply @is_trunc.is_contr_eq _ _,
+            
+            refine @is_equiv.is_contr_fiber_of_is_equiv _ _
+                h.1 (_: _) (h.1 y),
+            exact @is_equiv.is_equiv_inv _ _ f (qinv_to_is_equiv h)
+        end
+
+    @[hott] def is_hae_l_equiv_sigma_char (f: A → B)
+            : is_hae_l f ≃ Σ(l: has_linv f) (r: rinv l.1 f), 
+                                Π(y: B), lcoh f ⟨l.1, (l.2, r)⟩ y :=
+        begin
+            apply hott.equiv.trans,
+            exact (sigma.sigma_assoc_equiv
+                (λ u: qinv f, Π(y: B), lcoh f u y))⁻¹ᵉ,
+            apply hott.equiv.trans,
+            exact sigma.sigma_equiv_sigma_right
+                (λ g: B → A, @sigma.sigma_equiv_sigma_left _ (Σ(l: linv g f), rinv g f)
+                    (λ p: linv g f × rinv g f, Π(y: B), lcoh f ⟨g, p⟩ y)
+                    (@hott.equiv.symm (Σ(l: linv g f), rinv g f) _ (sigma.equiv_prod (linv g f) (rinv g f)))
+                ),
+            dsimp,
+            apply hott.equiv.trans,
+            exact sigma.sigma_equiv_sigma_right
+                (λ g: B → A, 
+                    (sigma.sigma_assoc_equiv
+                        (λ u: Σ(l: linv g f), rinv g f, Π (y : B), lcoh f ⟨g, (sigma.equiv_prod (linv g f) (rinv g f)).to_fun u⟩ y))⁻¹ᵉ
+                ),
+            exact sigma.sigma_assoc_equiv
+                (λ l: has_linv f, Σ(r: rinv l.1 f), Π(y: B), lcoh f ⟨l.1, (l.2, r)⟩ y)
+        end
+
+    @[hott] def is_hae_l_is_contr (f: A → B) (h: is_hae_l f)
+            : is_contr (is_hae_l f) :=
+        begin
+            refine is_trunc.is_trunc_equiv_closed -2
+                (is_hae_l_equiv_sigma_char f)⁻¹ᵉ
+                (@sigma.is_trunc_sigma _ (λ l: has_linv f, Σ(r: rinv l.1 f), Π(y: B), lcoh f ⟨l.1, (l.2, r)⟩ y) -2
+                    (is_contr_has_linv f h.1)
+                    (λ l: has_linv f, _: _)
+                ),
+            dsimp,
+            have := (@is_trunc.eq_of_is_contr _ (is_contr_has_linv f h.1) ⟨h.1.1, h.1.2.1⟩ l),
+            exact is_contr_lcoh f ⟨l.1, (l.2, transport (λ g: B → A, rinv g f) this..1 h.1.2.2)⟩
+        end
+
+    @[hott] def fae (f: A → B) : Type _ :=
+    Σ(h: qinv f), (Π(x: A), rcoh f h x) × (Π(y: B), lcoh f h y)
+
+end 


### PR DESCRIPTION
adj.lean contains definitions and theorems regarding half adjoint equivalences which formalize 
4.2.3, 4.2.7, 4.2.9, 4.2.10, 4.2.12, and 4.2.13 from section 4.2 of the HoTT Book.
2adj.lean contains definitions and theorems regarding half 2-adjoint equivalences which formalize analogous theorems to that of 4.2.3, 4.2.12, 4.2.13 from section 4.2 of the HoTT Book.